### PR TITLE
Fix issue #5

### DIFF
--- a/acumulus_connect_functions.php
+++ b/acumulus_connect_functions.php
@@ -518,7 +518,7 @@ function acumulus_connect_getVatType(array $config, array $invoice, array $clien
                 // Bedrijf.
                 $taxRate = '0.00';
             }
-        } elseif (empty($client['companyname'])) {
+        } elseif (empty($client['tax_id'])) {
             // Particulier.
             // WHMCS zijn digitale diensten.
             $vatType = '6';


### PR DESCRIPTION
This fixes issue #5 

The original author of this module assumed that if `companyname` is filled in with a customer within EU, it will push it as VAT-reversed invoice to Acumulus. This is *not* correct.

Now we determine a company based on VAT number, why?
- It's possible that a customer enters a company name (without reason), without being an actual company.
- It's possible to have a VAT number without a company name.

Tested and working in our setup.